### PR TITLE
Kubelet custom opts + backport of recent enhancements

### DIFF
--- a/containerized-test-run
+++ b/containerized-test-run
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+COREOS_KUBERNETES_ROOT=$(git rev-parse --show-toplevel)
+KUBERNETES_MOUNT_DIR="/go/src/github.com/kubernetes-incubator/kube-aws"
+
+docker run --rm -i \
+    -v "${COREOS_KUBERNETES_ROOT}:${KUBERNETES_MOUNT_DIR}:z" -w ${KUBERNETES_MOUNT_DIR} \
+    golang:1.8.3 ./make/test

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -38,6 +38,9 @@ func NewDefaultCluster() *Cluster {
 			PodSecurityPolicy{
 				Enabled: false,
 			},
+			DenyEscalatingExec{
+				Enabled: false,
+			},
 		},
 		AuditLog: AuditLog{
 			Enabled: false,
@@ -692,10 +695,15 @@ type Experimental struct {
 }
 
 type Admission struct {
-	PodSecurityPolicy PodSecurityPolicy `yaml:"podSecurityPolicy"`
+	PodSecurityPolicy  PodSecurityPolicy  `yaml:"podSecurityPolicy"`
+	DenyEscalatingExec DenyEscalatingExec `yaml:"denyEscalatingExec"`
 }
 
 type PodSecurityPolicy struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type DenyEscalatingExec struct {
 	Enabled bool `yaml:"enabled"`
 }
 

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -74,6 +74,7 @@ func NewDefaultCluster() *Cluster {
 		Kube2IamSupport: Kube2IamSupport{
 			Enabled: false,
 		},
+		KubeletOpts: "",
 		LoadBalancer: LoadBalancer{
 			Enabled: false,
 		},
@@ -682,6 +683,7 @@ type Experimental struct {
 	TLSBootstrap                TLSBootstrap                   `yaml:"tlsBootstrap"`
 	EphemeralImageStorage       EphemeralImageStorage          `yaml:"ephemeralImageStorage"`
 	Kube2IamSupport             Kube2IamSupport                `yaml:"kube2IamSupport,omitempty"`
+	KubeletOpts                 string                         `yaml:"kubeletOpts,omitempty"`
 	LoadBalancer                LoadBalancer                   `yaml:"loadBalancer"`
 	TargetGroup                 TargetGroup                    `yaml:"targetGroup"`
 	NodeDrainer                 model.NodeDrainer              `yaml:"nodeDrainer"`

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1389,7 +1389,7 @@ write_files:
           - --authentication-token-webhook-cache-ttl={{ .Experimental.Authentication.Webhook.CacheTTL }}
           {{ end }}
           - --advertise-address=$private_ipv4
-          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }},ResourceQuota
+          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }},ResourceQuota,{{if .Experimental.Admission.DenyEscalatingExec.Enabled}}DenyEscalatingExec{{end}}
           - --anonymous-auth=false
           {{if .Experimental.Dex.Enabled}}
           - --oidc-issuer-url={{.Experimental.Dex.Url}}

--- a/core/controlplane/config/templates/cloud-config-worker
+++ b/core/controlplane/config/templates/cloud-config-worker
@@ -567,7 +567,7 @@ write_files:
     permissions: 0755
     owner: root:root
     content: |
-      KUBELET_OPTS=""
+      KUBELET_OPTS="{{.Experimental.KubeletOpts}}"
 
   - path: /etc/kubernetes/cni/docker_opts_cni.env
     content: |

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -1144,6 +1144,8 @@ addons:
 #   admission:
 #     podSecurityPolicy:
 #       enabled: true
+#     denyEscalatingExec:
+#       enabled: true
 #   # Used to provide `/etc/environment` env vars with values from arbitrary CloudFormation refs
 #   awsEnvironment:
 #     enabled: true

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -1156,6 +1156,7 @@ experimental:
     enabled: true
   kube2IamSupport:
     enabled: true
+  kubeletOpts: '--image-gc-low-threshold 60 --image-gc-high-threshold 70'
   loadBalancer:
     enabled: true
     names:
@@ -1258,6 +1259,7 @@ worker:
 						Kube2IamSupport: controlplane_config.Kube2IamSupport{
 							Enabled: true,
 						},
+						KubeletOpts: "--image-gc-low-threshold 60 --image-gc-high-threshold 70",
 						LoadBalancer: controlplane_config.LoadBalancer{
 							Enabled:          true,
 							Names:            []string{"manuallymanagedlb"},

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -80,6 +80,9 @@ func TestMainClusterConfig(t *testing.T) {
 				PodSecurityPolicy: controlplane_config.PodSecurityPolicy{
 					Enabled: false,
 				},
+				DenyEscalatingExec: controlplane_config.DenyEscalatingExec{
+					Enabled: false,
+				},
 			},
 			AuditLog: controlplane_config.AuditLog{
 				Enabled: false,
@@ -1130,6 +1133,8 @@ experimental:
   admission:
     podSecurityPolicy:
       enabled: true
+    denyEscalatingExec:
+      enabled: true
   auditLog:
     enabled: true
     maxage: 100
@@ -1212,6 +1217,9 @@ worker:
 					expected := controlplane_config.Experimental{
 						Admission: controlplane_config.Admission{
 							PodSecurityPolicy: controlplane_config.PodSecurityPolicy{
+								Enabled: true,
+							},
+							DenyEscalatingExec: controlplane_config.DenyEscalatingExec{
 								Enabled: true,
 							},
 						},


### PR DESCRIPTION
* New feature: custom Kubelet opts (main use case for us is https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/ )
* Backport of https://github.com/kubernetes-incubator/kube-aws/pull/770 and https://github.com/kubernetes-incubator/kube-aws/pull/752
