### PR TITLE
Fix managed role name validation

### DIFF
--- a/cfnresource/naming.go
+++ b/cfnresource/naming.go
@@ -12,3 +12,12 @@ func ValidateRoleNameLength(clusterName string, nestedStackLogicalName string, m
 	}
 	return nil
 }
+
+func ValidateManagedRoleNameLength(managedIAMRoleName string, region string) error {
+	name := fmt.Sprintf("%s-%s", region, managedIAMRoleName)
+	if len(name) > 64 {
+		limit := 64 - len(name) + len(managedIAMRoleName)
+		return fmt.Errorf("IAM role name(=%s) will be %d characters long. It exceeds the AWS limit of 64 characters: region name(=%s) + managed iam role name(=%s) should be less than or equal to %d", name, len(name), region, managedIAMRoleName, limit)
+	}
+	return nil
+}

--- a/cfnresource/naming_test.go
+++ b/cfnresource/naming_test.go
@@ -14,3 +14,16 @@ func TestValidateRoleNameLength(t *testing.T) {
 		}
 	})
 }
+
+func TestValidateManagedRoleNameLength(t *testing.T) {
+	t.Run("WhenMax", func(t *testing.T) {
+		if e := ValidateManagedRoleNameLength("prod-workers", "ap-southeast-1"); e != nil {
+			t.Errorf("expected validation to succeed but failed: %v", e)
+		}
+	})
+	t.Run("WhenTooLong", func(t *testing.T) {
+		if e := ValidateManagedRoleNameLength("prod-workers-role-with-very-very-very-very-very-long-name", "ap-southeast-1"); e == nil {
+			t.Error("expected validation to fail but succeeded")
+		}
+	})
+}

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -1023,8 +1023,14 @@ func (c Cluster) validate() error {
 		fmt.Println(`WARNING: instance types "t2.nano" and "t2.micro" are not recommended. See https://github.com/kubernetes-incubator/kube-aws/issues/258 for more information`)
 	}
 
-	if e := cfnresource.ValidateRoleNameLength(c.ClusterName, c.NestedStackName(), c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
-		return e
+	if len(c.Controller.IAMConfig.Role.Name) > 0 {
+		if e := cfnresource.ValidateManagedRoleNameLength(c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
+			return e
+		}
+	} else {
+		if e := cfnresource.ValidateRoleNameLength(c.ClusterName, c.NestedStackName(), c.Controller.IAMConfig.Role.Name, c.Region.String()); e != nil {
+			return e
+		}
 	}
 
 	return nil

--- a/core/nodepool/config/config.go
+++ b/core/nodepool/config/config.go
@@ -334,8 +334,14 @@ func (c ProvidedConfig) validate() error {
 		return fmt.Errorf("awsNodeLabels can't be enabled for node pool because the total number of characters in clusterName(=\"%s\") + node pool's name(=\"%s\") exceeds the limit of %d", c.ClusterName, c.NodePoolName, limit)
 	}
 
-	if e := cfnresource.ValidateRoleNameLength(c.ClusterName, c.NestedStackName(), c.WorkerNodePoolConfig.IAMConfig.Role.Name, c.Region.String()); e != nil {
-		return e
+	if len(c.WorkerNodePoolConfig.IAMConfig.Role.Name) > 0 {
+		if e := cfnresource.ValidateManagedRoleNameLength(c.WorkerNodePoolConfig.IAMConfig.Role.Name, c.Region.String()); e != nil {
+			return e
+		}
+	} else {
+		if e := cfnresource.ValidateRoleNameLength(c.ClusterName, c.NestedStackName(), c.WorkerNodePoolConfig.IAMConfig.Role.Name, c.Region.String()); e != nil {
+			return e
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When creating iam roles for the controller or node pools, validation checks for the whole string consisting of `<cluster_name>-<nested_stack_name>-<12_characters_random_alphanumeric_characters>-<region>-<iam_role_name>`. The validation works as intended if `iam.role.name` is not specified and auto-generated.

However when `iam.role.name` is specified, kube-aws is actually creating `<region_name>-<managed_role_name>` so for the following config it'll actually create a role named `<region>-myrole` so a new validation is needed.

```
      iam:
        role:
          name: "myrole"
```

This allows for a little bit more leeway to have a more meaningful name for the fixed role.