### PR TITLE
SRE-400 Configurable networking daemonset requests

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1989,11 +1989,11 @@ write_files:
               - --kube-subnet-mgr
               resources:
                 requests:
-                  cpu: "100m"
-                  memory: "50Mi"
+                  cpu: {{ .Kubernetes.Networking.SelfHosting.Resources.Requests.Cpu }}
+                  memory: {{ .Kubernetes.Networking.SelfHosting.Resources.Requests.Memory }}
                 limits:
-                  cpu: "100m"
-                  memory: "50Mi"
+                  cpu: {{ .Kubernetes.Networking.SelfHosting.Resources.Limits.Cpu }}
+                  memory: {{ .Kubernetes.Networking.SelfHosting.Resources.Limits.Memory }}
               securityContext:
                 privileged: true
               env:

--- a/model/pod_resources.go
+++ b/model/pod_resources.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"regexp"
+)
+
+type PodResources struct {
+	Cpu    string `yaml:"cpu"`
+	Memory string `yaml:"memory"`
+}
+
+func (r PodResources) IsValid() bool {
+	match, _ := regexp.MatchString("([0-9]+m)$", r.Cpu)
+	if !match {
+		return false
+	}
+
+	match, _ = regexp.MatchString("([0-9]+[M|G]i)$", r.Memory)
+	if !match {
+		return false
+	}
+
+	return true
+}

--- a/model/pod_resources_test.go
+++ b/model/pod_resources_test.go
@@ -1,0 +1,51 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestInvalidCpu(t *testing.T) {
+	res := PodResources{Cpu: "12", Memory: "100Mi"}
+	if res.IsValid() {
+		t.Errorf("Expected the test to fail as the cpu is invalid.")
+	}
+
+	res = PodResources{Cpu: "abdbsd", Memory: "100Mi"}
+	if res.IsValid() {
+		t.Errorf("Expected the test to fail as the cpu is invalid.")
+	}
+
+	res = PodResources{Cpu: "30b", Memory: "100Mi"}
+	if res.IsValid() {
+		t.Errorf("Expected the test to fail as the cpu is invalid.")
+	}
+}
+
+func TestInvalidMemory(t *testing.T) {
+	res := PodResources{Cpu: "100m", Memory: "asdba"}
+	if res.IsValid() {
+		t.Errorf("Expected the test to fail as the memory is invalid.")
+	}
+
+	res = PodResources{Cpu: "100m", Memory: "100m"}
+	if res.IsValid() {
+		t.Errorf("Expected the test to fail as the memory is invalid.")
+	}
+
+	res = PodResources{Cpu: "100m", Memory: "50Mid"}
+	if res.IsValid() {
+		t.Errorf("Expected the test to fail as the memory is invalid.")
+	}
+}
+
+func TestValidRequests(t *testing.T) {
+	res := PodResources{Cpu: "100m", Memory: "20Mi"}
+	if !res.IsValid() {
+		t.Errorf("Expected the test to fail as the memory is invalid.")
+	}
+
+	res = PodResources{Cpu: "5m", Memory: "500Gi"}
+	if !res.IsValid() {
+		t.Errorf("Expected the test to fail as the memory is invalid.")
+	}
+}


### PR DESCRIPTION
### Overview
The default requests (**100m and 50Mi**) and limits for flannel daemonset are not enough for our production cluster. We'll need to update `kube-aws` to allow configurable requests and limits for networking ds. With current limits, the pods are getting internal errors while allocating more memory which causes some interruptions.

### Note
Please note that we are going to remove the limits and requests for the flannel daemonset as it traditionally never had those limits when running as a systemd unit.