### PR TITLE
SRE-400 removing flannel daemonset restrains

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -1987,13 +1987,6 @@ write_files:
               args:
               - --ip-masq
               - --kube-subnet-mgr
-              resources:
-                requests:
-                  cpu: "100m"
-                  memory: "50Mi"
-                limits:
-                  cpu: "100m"
-                  memory: "50Mi"
               securityContext:
                 privileged: true
               env:


### PR DESCRIPTION
### Overview
The `flannel` daemonset is configured to use 100m and 50Mi of resources. Unfortunately, this is not enough for our production cluster. The flannel ds pods are throwing internal errors while allocating more memory and also getting OOMKilled. Following are the journal logs:

`
Feb 21 11:03:43 ip-10-200-161-80.prod.local kernel:  mem_cgroup_oom_synchronize+0x2ed/0x330
Feb 21 11:03:43 ip-10-200-161-80.prod.local kernel: [ pid ]   uid  tgid total_vm      rss nr_ptes nr_pmds swapents oom_score_adj name
Feb 21 11:03:43 ip-10-200-161-80.prod.local kernel: oom_reaper: reaped process 23319 (iptables), now anon-rss:0kB, file-rss:0kB, shmem-rss:0kB
Feb 21 11:03:49 ip-10-200-161-80.prod.local kernel: iptables invoked oom-killer: gfp_mask=0x14000c0(GFP_KERNEL), nodemask=(null),  order=0, oom_score_adj=999
Feb 21 11:03:49 ip-10-200-161-80.prod.local kernel:  oom_kill_process+0x213/0x410
Feb 21 11:03:49 ip-10-200-161-80.prod.local kernel:  mem_cgroup_oom_synchronize+0x2ed/0x330
Feb 21 11:03:49 ip-10-200-161-80.prod.local kernel: [ pid ]   uid  tgid total_vm      rss nr_ptes nr_pmds swapents oom_score_adj name
Feb 21 11:03:49 ip-10-200-161-80.prod.local kernel: oom_reaper: reaped process 23323 (iptables), now anon-rss:0kB, file-rss:0kB, shmem-rss:0kB
`

### Proposed solution
Instead of making the requests and limits configurable, we'd like to remove the restrains to allow flannel to use more resources if required. That was the case when flannel was running as a systemd unit. I've checked that the flannel container in canal mode doesn't have any requests and limits hardcoded.