### PR TITLE
kube-proxy - fix isolated xtables lock

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -3120,6 +3120,9 @@ write_files:
                 - mountPath: /etc/kubernetes/kube-proxy
                   name: kube-proxy-config
                   readOnly: true
+                - mountPath: /run/xtables.lock
+                  name: xtables
+                  readOnly: false
               volumes:
               {{if .KubeProxy.IPVSMode.Enabled -}}
               - name: lib-modules
@@ -3132,6 +3135,9 @@ write_files:
               - name: kube-proxy-config
                 configMap:
                   name: kube-proxy-config
+              - name: xtables
+                hostPath:
+                  path: /run/xtables.lock
 
   - path: /etc/kubernetes/manifests/kube-apiserver.yaml
     content: |


### PR DESCRIPTION
### Overview
Currently, we are seeing a high number of error messages in `flannel` logs about it failing to acquire iptables lock. There seems to be contention between `flannel` and `kube-proxy`. Ideally, both the daemonsets needs to acquire socket locks via `/run/xtables.lock` file but `kube-proxy` is not honouring the lock file. This is because the lock file is not mounted in the spec, so basically it creates its own `xtables.lock` file within the container.

### Code changes
Mounting the `/run/xtables.lock` file in `kube-proxy` daemonset spec such that it shares the lock with flannel daemonset.

### Testing
Testing will be performed in the staging cluster by spinning up and down a few services and pods within a small period. This will cause the flannel and kube-proxy daemonsets to fight for iptable resulting in the lock contention.

### Release
Releasing the changes requires rolling only the master nodes. The first master node will apply the daemonset spec change. Please note that it's not a disruptive change.